### PR TITLE
5 - Updating React state after PUT and DELETE

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ function App() {
   const [message, setMessage] = useState("");
   const [noteIdToEdit, setNoteIdToEdit] = useState("");
   const [updatedNote, setUpdatedNote] = useState("");
+  //const selectedUserId = data[0]?.userId; // derived state (derived from data)
 
   useEffect(() => {
     getData();
@@ -35,6 +36,12 @@ function App() {
     const message = await res.json();
     setMessage(message);
     setNote("");
+
+    // we can't yet update our React state because we don't know the id of the newly created note
+    /* setData([
+      ...data,
+      { id: ???, content: note, name: user, userId: selectedUserId },
+    ]); */
   }
 
   async function deleteNote(noteId) {
@@ -43,6 +50,7 @@ function App() {
     });
     const message = await res.json();
     setMessage(message);
+    setData(data.filter((note) => note.id != noteId));
   }
 
   function toggleEditMode(noteId, noteToEdit) {
@@ -67,6 +75,11 @@ function App() {
     const message = await res.json();
     setMessage(message);
     toggleEditMode();
+    setData(
+      data.map((note) =>
+        note.id == noteId ? { ...note, content: updatedNote } : note
+      )
+    );
   }
 
   return (


### PR DESCRIPTION
### 🪄Part 5 - Update React state🪄

✨After sending a `PUT` or `DELETE` request, update the state in React.
- [x] use the `filter` method to remove the note from `data` ✅
- [x] use the `map` method to change the `content` of one single note ✅

🌟For now, we can't update our React state after adding a new note. That's because the backend doesn't send us back the `id` of the new note that was created. We'll have to adjust our code in the Express app and send the id as our response.